### PR TITLE
FIX: functional workflow

### DIFF
--- a/fmriprep_rodents/interfaces/confounds.py
+++ b/fmriprep_rodents/interfaces/confounds.py
@@ -29,7 +29,7 @@ class GatherConfoundsInputSpec(BaseInterfaceInputSpec):
     dvars = File(exists=True, desc='file containing DVARS')
     std_dvars = File(exists=True, desc='file containing standardized DVARS')
     fd = File(exists=True, desc='input framewise displacement')
-    rmsd = File(exists=True, desc='input RMS framewise displacement')
+    # rmsd = File(exists=True, desc='input RMS framewise displacement')
     tcompcor = File(exists=True, desc='input tCompCorr')
     acompcor = File(exists=True, desc='input aCompCorr')
     cos_basis = File(exists=True, desc='input cosine basis')
@@ -83,7 +83,7 @@ class GatherConfounds(SimpleInterface):
             dvars=self.inputs.dvars,
             std_dvars=self.inputs.std_dvars,
             fdisp=self.inputs.fd,
-            rmsd=self.inputs.rmsd,
+            # rmsd=self.inputs.rmsd,
             tcompcor=self.inputs.tcompcor,
             acompcor=self.inputs.acompcor,
             cos_basis=self.inputs.cos_basis,
@@ -136,8 +136,8 @@ class ICAConfounds(SimpleInterface):
         return runtime
 
 
-def _gather_confounds(signals=None, dvars=None, std_dvars=None, fdisp=None,
-                      rmsd=None, tcompcor=None, acompcor=None, cos_basis=None,
+def _gather_confounds(signals=None, dvars=None, std_dvars=None, fdisp=None,  # rmsd=None,
+                      tcompcor=None, acompcor=None, cos_basis=None,
                       motion=None, aroma=None, newpath=None):
     r"""
     Load confounds from the filenames, concatenate together horizontally
@@ -188,7 +188,7 @@ def _gather_confounds(signals=None, dvars=None, std_dvars=None, fdisp=None,
                            (std_dvars, 'Standardized DVARS'),
                            (dvars, 'DVARS'),
                            (fdisp, 'Framewise displacement'),
-                           (rmsd, 'Framewise displacement (RMS)'),
+                        #    (rmsd, 'Framewise displacement (RMS)'),
                            (tcompcor, 'tCompCor'),
                            (acompcor, 'aCompCor'),
                            (cos_basis, 'Cosine basis'),

--- a/fmriprep_rodents/patch/workflows/func.py
+++ b/fmriprep_rodents/patch/workflows/func.py
@@ -167,9 +167,6 @@ methodology of *fMRIPrep*.
         (inputnode, val_bold, [(("bold_file", listify), "in_file")]),
         (inputnode, calc_dummy_scans, [("dummy_scans", "dummy_scans")]),
         (val_bold, gen_ref, [("out_file", "in_file")]),
-        (gen_ref, brain_extraction_wf, [
-            ("ref_image", "inputnode.in_files"),
-        ]),
         (val_bold, bold_1st, [(("out_file", listify), "inlist")]),
         (gen_ref, calc_dummy_scans, [("n_volumes_to_discard", "algo_dummy_scans")]),
         (calc_dummy_scans, outputnode, [("skip_vols_num", "skip_vols")]),
@@ -177,16 +174,25 @@ methodology of *fMRIPrep*.
             ("ref_image", "raw_ref_image"),
             ("n_volumes_to_discard", "algo_dummy_scans"),
         ]),
-        (brain_extraction_wf, outputnode, [
-            ("outputnode.out_corrected", "ref_image"),
-            ("outputnode.out_mask", "bold_mask"),
-            ("outputnode.out_brain", "ref_image_brain"),
-        ]),
         (val_bold, validate_1st, [(("out_report", listify), "inlist")]),
         (bold_1st, outputnode, [("out", "bold_file")]),
         (validate_1st, outputnode, [("out", "validation_report")]),
     ])
     # fmt: on
+
+    if not pre_mask:
+        # fmt: off
+        workflow.connect([
+            (gen_ref, brain_extraction_wf, [
+                ("ref_image", "inputnode.in_files"),
+            ]),
+            (brain_extraction_wf, outputnode, [
+                ("outputnode.out_corrected", "ref_image"),
+                ("outputnode.out_mask", "bold_mask"),
+                ("outputnode.out_brain", "ref_image_brain"),
+            ]),
+        ])
+        # fmt: on
 
     if sbref_files:
         nsbrefs = 0

--- a/fmriprep_rodents/patch/workflows/func.py
+++ b/fmriprep_rodents/patch/workflows/func.py
@@ -1,0 +1,229 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+"""Patched functional workflows."""
+from pkg_resources import resource_filename as pkgr_fn
+
+from nipype.pipeline import engine as pe
+from nipype.interfaces import utility as niu, fsl, afni
+
+from templateflow.api import get as get_template
+from nirodents.workflows.brainextraction import init_rodent_brain_extraction_wf
+from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+from niworkflows.interfaces.fixes import (
+    FixHeaderRegistration as Registration,
+    FixHeaderApplyTransforms as ApplyTransforms,
+    FixN4BiasFieldCorrection as N4BiasFieldCorrection,
+)
+from niworkflows.interfaces.images import RegridToZooms, ValidateImage, MatchHeader
+from niworkflows.interfaces.masks import SimpleShowMaskRPT
+from niworkflows.interfaces.registration import EstimateReferenceImage
+from niworkflows.interfaces.utils import CopyXForm
+from niworkflows.utils.connections import listify
+from niworkflows.utils.misc import pass_dummy_scans as _pass_dummy_scans
+
+
+DEFAULT_MEMORY_MIN_GB = 0.01
+
+
+def init_bold_reference_wf(
+    omp_nthreads,
+    bold_file=None,
+    sbref_files=None,
+    brainmask_thresh=0.85,
+    pre_mask=False,
+    multiecho=False,
+    name="bold_reference_wf",
+    gen_report=False,
+):
+    """
+    Build a workflow that generates reference BOLD images for a series.
+    The raw reference image is the target of :abbr:`HMC (head motion correction)`, and a
+    contrast-enhanced reference is the subject of distortion correction, as well as
+    boundary-based registration to T1w and template spaces.
+    Workflow Graph
+        .. workflow::
+            :graph2use: orig
+            :simple_form: yes
+            from niworkflows.func.util import init_bold_reference_wf
+            wf = init_bold_reference_wf(omp_nthreads=1)
+    Parameters
+    ----------
+    omp_nthreads : :obj:`int`
+        Maximum number of threads an individual process may use
+    bold_file : :obj:`str`
+        BOLD series NIfTI file
+    sbref_files : :obj:`list` or :obj:`bool`
+        Single band (as opposed to multi band) reference NIfTI file.
+        If ``True`` is passed, the workflow is built to accommodate SBRefs,
+        but the input is left undefined (i.e., it is left open for connection)
+    brainmask_thresh: :obj:`float`
+        Lower threshold for the probabilistic brainmask to obtain
+        the final binary mask (default: 0.85).
+    pre_mask : :obj:`bool`
+        Indicates whether the ``pre_mask`` input will be set (and thus, step 1
+        should be skipped).
+    multiecho : :obj:`bool`
+        If multiecho data was supplied, data from the first echo
+        will be selected
+    name : :obj:`str`
+        Name of workflow (default: ``bold_reference_wf``)
+    gen_report : :obj:`bool`
+        Whether a mask report node should be appended in the end
+    Inputs
+    ------
+    bold_file : str
+        BOLD series NIfTI file
+    bold_mask : bool
+        A tentative brain mask to initialize the workflow (requires ``pre_mask``
+        parameter set ``True``).
+    dummy_scans : int or None
+        Number of non-steady-state volumes specified by user at beginning of ``bold_file``
+    sbref_file : str
+        single band (as opposed to multi band) reference NIfTI file
+    Outputs
+    -------
+    bold_file : str
+        Validated BOLD series NIfTI file
+    raw_ref_image : str
+        Reference image to which BOLD series is motion corrected
+    skip_vols : int
+        Number of non-steady-state volumes selected at beginning of ``bold_file``
+    algo_dummy_scans : int
+        Number of non-steady-state volumes agorithmically detected at
+        beginning of ``bold_file``
+    ref_image : str
+        Contrast-enhanced reference image
+    ref_image_brain : str
+        Skull-stripped reference image
+    bold_mask : str
+        Skull-stripping mask of reference image
+    validation_report : str
+        HTML reportlet indicating whether ``bold_file`` had a valid affine
+    Subworkflows
+        * :py:func:`~niworkflows.func.util.init_enhance_and_skullstrip_wf`
+    """
+    workflow = Workflow(name=name)
+    workflow.__desc__ = f"""\
+First, a reference volume and its skull-stripped version were generated
+{'from the shortest echo of the BOLD run' * multiecho} using a custom
+methodology of *fMRIPrep*.
+"""
+
+    inputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=["bold_file", "bold_mask", "dummy_scans", "sbref_file"]
+        ),
+        name="inputnode",
+    )
+    outputnode = pe.Node(
+        niu.IdentityInterface(
+            fields=[
+                "bold_file",
+                "raw_ref_image",
+                "skip_vols",
+                "algo_dummy_scans",
+                "ref_image",
+                "ref_image_brain",
+                "bold_mask",
+                "validation_report",
+                "mask_report",
+            ]
+        ),
+        name="outputnode",
+    )
+
+    # Simplify manually setting input image
+    if bold_file is not None:
+        inputnode.inputs.bold_file = bold_file
+
+    val_bold = pe.MapNode(
+        ValidateImage(),
+        name="val_bold",
+        mem_gb=DEFAULT_MEMORY_MIN_GB,
+        iterfield=["in_file"],
+    )
+
+    gen_ref = pe.Node(
+        EstimateReferenceImage(multiecho=multiecho), name="gen_ref", mem_gb=1
+    )  # OE: 128x128x128x50 * 64 / 8 ~ 900MB.
+
+    brain_extraction_wf = init_rodent_brain_extraction_wf(
+        ants_affine_init=False,
+    )
+
+    calc_dummy_scans = pe.Node(
+        niu.Function(function=_pass_dummy_scans, output_names=["skip_vols_num"]),
+        name="calc_dummy_scans",
+        run_without_submitting=True,
+        mem_gb=DEFAULT_MEMORY_MIN_GB,
+    )
+    bold_1st = pe.Node(niu.Select(index=[0]),
+                       name="bold_1st", run_without_submitting=True)
+    validate_1st = pe.Node(niu.Select(index=[0]),
+                           name="validate_1st", run_without_submitting=True)
+
+    # fmt: off
+    workflow.connect([
+        (inputnode, val_bold, [(("bold_file", listify), "in_file")]),
+        (inputnode, calc_dummy_scans, [("dummy_scans", "dummy_scans")]),
+        (val_bold, gen_ref, [("out_file", "in_file")]),
+        (gen_ref, brain_extraction_wf, [
+            ("ref_image", "inputnode.in_files"),
+        ]),
+        (val_bold, bold_1st, [(("out_file", listify), "inlist")]),
+        (gen_ref, calc_dummy_scans, [("n_volumes_to_discard", "algo_dummy_scans")]),
+        (calc_dummy_scans, outputnode, [("skip_vols_num", "skip_vols")]),
+        (gen_ref, outputnode, [
+            ("ref_image", "raw_ref_image"),
+            ("n_volumes_to_discard", "algo_dummy_scans"),
+        ]),
+        (brain_extraction_wf, outputnode, [
+            ("outputnode.out_corrected", "ref_image"),
+            ("outputnode.out_mask", "bold_mask"),
+            ("outputnode.out_brain", "ref_image_brain"),
+        ]),
+        (val_bold, validate_1st, [(("out_report", listify), "inlist")]),
+        (bold_1st, outputnode, [("out", "bold_file")]),
+        (validate_1st, outputnode, [("out", "validation_report")]),
+    ])
+    # fmt: on
+
+    if sbref_files:
+        nsbrefs = 0
+        if sbref_files is not True:
+            # If not boolean, then it is a list-of or pathlike.
+            inputnode.inputs.sbref_file = sbref_files
+            nsbrefs = 1 if isinstance(sbref_files, str) else len(sbref_files)
+
+        val_sbref = pe.MapNode(
+            ValidateImage(),
+            name="val_sbref",
+            mem_gb=DEFAULT_MEMORY_MIN_GB,
+            iterfield=["in_file"],
+        )
+        # fmt: off
+        workflow.connect([
+            (inputnode, val_sbref, [(("sbref_file", listify), "in_file")]),
+            (val_sbref, gen_ref, [("out_file", "sbref_file")]),
+        ])
+        # fmt: on
+
+        # Edit the boilerplate as the SBRef will be the reference
+        workflow.__desc__ = f"""\
+First, a reference volume and its skull-stripped version were generated
+by aligning and averaging{' the first echo of' * multiecho}
+{nsbrefs or ''} single-band references (SBRefs).
+"""
+
+    if gen_report:
+        mask_reportlet = pe.Node(SimpleShowMaskRPT(), name="mask_reportlet")
+        # fmt: off
+        workflow.connect([
+            (brain_extraction_wf, mask_reportlet, [
+                ("outputnode.out_corrected", "background_file"),
+                ("outputnode.out_mask", "mask_file"),
+            ]),
+        ])
+        # fmt: on
+
+    return workflow

--- a/fmriprep_rodents/workflows/bold/base.py
+++ b/fmriprep_rodents/workflows/bold/base.py
@@ -26,7 +26,6 @@ from ...interfaces import DerivativesDataSink
 from ...interfaces.reports import FunctionalSummary
 
 # BOLD workflows
-from ...patch.workflows.func import init_bold_reference_wf
 from .confounds import init_bold_confs_wf, init_carpetplot_wf
 from .hmc import init_bold_hmc_wf
 from .stc import init_bold_stc_wf
@@ -144,6 +143,8 @@ def init_func_preproc_wf(bold_file):
     from niworkflows.interfaces.utils import DictMerge
     from sdcflows.workflows.base import init_sdc_estimate_wf, fieldmap_wrangler
 
+    from ...patch.workflows.func import init_bold_reference_wf
+    
     mem_gb = {'filesize': 1, 'resampled': 1, 'largemem': 1}
     bold_tlen = 10
 

--- a/fmriprep_rodents/workflows/bold/base.py
+++ b/fmriprep_rodents/workflows/bold/base.py
@@ -477,15 +477,13 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         (inputnode, bold_confounds_wf, [('anat_tpms', 'inputnode.t1w_tpms'),
                                         ('anat_mask', 'inputnode.t1w_mask')]),
         (bold_hmc_wf, bold_confounds_wf, [
-            ('outputnode.movpar_file', 'inputnode.movpar_file'),
-            ('outputnode.rmsd_file', 'inputnode.rmsd_file')]),
+            ('outputnode.movpar_file', 'inputnode.movpar_file')]),
+            # ('outputnode.rmsd_file', 'inputnode.rmsd_file')]),
         (bold_reg_wf, bold_confounds_wf, [
             ('outputnode.itk_t1_to_bold', 'inputnode.t1_bold_xform')]),
         (bold_reference_wf, bold_confounds_wf, [
-            ('outputnode.skip_vols', 'inputnode.skip_vols')]),
-        (bold_bold_trans_wf, bold_confounds_wf, [
-            ('outputnode.bold_mask', 'inputnode.bold_mask'),
-        ]),
+            ('outputnode.skip_vols', 'inputnode.skip_vols'),
+            ('outputnode.bold_mask', 'inputnode.bold_mask')]),
         (bold_confounds_wf, outputnode, [
             ('outputnode.confounds_file', 'confounds'),
         ]),
@@ -794,10 +792,9 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 bold_grayords_wf, 'outputnode.cifti_bold', carpetplot_wf, 'inputnode.cifti_bold'
             )
         else:
-            # Need to work out how to change this for rodents
-            # Xform to 'MNI152NLin2009cAsym' is always computed.
+            # Xform to 'Fischer344' is always computed.
             carpetplot_select_std = pe.Node(
-                KeySelect(fields=['std2anat_xfm'], key='MNI152NLin2009cAsym'),
+                KeySelect(fields=['std2anat_xfm'], key='Fischer344'),
                 name='carpetplot_select_std', run_without_submitting=True)
 
             workflow.connect([
@@ -808,7 +805,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                     ('std2anat_xfm', 'inputnode.std2anat_xfm')]),
                 (bold_bold_trans_wf if not multiecho else bold_t2s_wf, carpetplot_wf, [
                     ('outputnode.bold', 'inputnode.bold')]),
-                (bold_bold_trans_wf, carpetplot_wf, [
+                (bold_reference_wf, carpetplot_wf, [
                     ('outputnode.bold_mask', 'inputnode.bold_mask')]),
                 (bold_reg_wf, carpetplot_wf, [
                     ('outputnode.itk_t1_to_bold', 'inputnode.t1_bold_xform')]),

--- a/fmriprep_rodents/workflows/bold/base.py
+++ b/fmriprep_rodents/workflows/bold/base.py
@@ -26,6 +26,7 @@ from ...interfaces import DerivativesDataSink
 from ...interfaces.reports import FunctionalSummary
 
 # BOLD workflows
+from ...patch.workflows.func import init_bold_reference_wf
 from .confounds import init_bold_confs_wf, init_carpetplot_wf
 from .hmc import init_bold_hmc_wf
 from .stc import init_bold_stc_wf
@@ -138,7 +139,6 @@ def init_func_preproc_wf(bold_file):
 
     """
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-    from niworkflows.func.util import init_bold_reference_wf
     from niworkflows.interfaces.nibabel import ApplyMask
     from niworkflows.interfaces.utility import KeySelect
     from niworkflows.interfaces.utils import DictMerge
@@ -794,6 +794,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
                 bold_grayords_wf, 'outputnode.cifti_bold', carpetplot_wf, 'inputnode.cifti_bold'
             )
         else:
+            # Need to work out how to change this for rodents
             # Xform to 'MNI152NLin2009cAsym' is always computed.
             carpetplot_select_std = pe.Node(
                 KeySelect(fields=['std2anat_xfm'], key='MNI152NLin2009cAsym'),

--- a/fmriprep_rodents/workflows/bold/confounds.py
+++ b/fmriprep_rodents/workflows/bold/confounds.py
@@ -178,7 +178,7 @@ Frames that exceeded a threshold of {fd} mm FD or {dv} standardised DVARS
 were annotated as motion outliers.
 """.format(fd=regressors_fd_th, dv=regressors_dvars_th)
     inputnode = pe.Node(niu.IdentityInterface(
-        fields=['bold', 'bold_mask', 'movpar_file', 'rmsd_file',
+        fields=['bold', 'bold_mask', 'movpar_file', # 'rmsd_file',
                 'skip_vols', 't1w_mask', 't1w_tpms', 't1_bold_xform']),
         name='inputnode')
     outputnode = pe.Node(niu.IdentityInterface(
@@ -188,7 +188,7 @@ were annotated as motion outliers.
     # Get masks ready in T1w space
     acc_tpm = pe.Node(AddTPMs(indices=[1, 2]),  # BIDS convention (WM=1, CSF=2)
                       name='acc_tpm')  # acc stands for aCompCor
-    csf_roi = pe.Node(TPM2ROI(erode_mm=0, mask_erode_mm=30), name='csf_roi')
+    csf_roi = pe.Node(TPM2ROI(erode_mm=0, mask_erode_mm=3), name='csf_roi')
     wm_roi = pe.Node(TPM2ROI(
         erode_prop=0.6, mask_erode_prop=0.6**3),  # 0.6 = radius; 0.6^3 = volume
         name='wm_roi')
@@ -264,9 +264,9 @@ were annotated as motion outliers.
     add_motion_headers = pe.Node(
         AddTSVHeader(columns=["trans_x", "trans_y", "trans_z", "rot_x", "rot_y", "rot_z"]),
         name="add_motion_headers", mem_gb=0.01, run_without_submitting=True)
-    add_rmsd_header = pe.Node(
-        AddTSVHeader(columns=["rmsd"]),
-        name="add_rmsd_header", mem_gb=0.01, run_without_submitting=True)
+    # add_rmsd_header = pe.Node(
+    #     AddTSVHeader(columns=["rmsd"]),
+    #     name="add_rmsd_header", mem_gb=0.01, run_without_submitting=True)
     concat = pe.Node(GatherConfounds(), name="concat", mem_gb=0.01, run_without_submitting=True)
 
     # CompCor metadata
@@ -391,7 +391,7 @@ were annotated as motion outliers.
 
         # Collate computed confounds together
         (inputnode, add_motion_headers, [('movpar_file', 'in_file')]),
-        (inputnode, add_rmsd_header, [('rmsd_file', 'in_file')]),
+        # (inputnode, add_rmsd_header, [('rmsd_file', 'in_file')]),
         (dvars, add_dvars_header, [('out_nstd', 'in_file')]),
         (dvars, add_std_dvars_header, [('out_std', 'in_file')]),
         (signals, concat, [('out_file', 'signals')]),
@@ -400,7 +400,7 @@ were annotated as motion outliers.
                             ('pre_filter_file', 'cos_basis')]),
         (acompcor, concat, [('components_file', 'acompcor')]),
         (add_motion_headers, concat, [('out_file', 'motion')]),
-        (add_rmsd_header, concat, [('out_file', 'rmsd')]),
+        # (add_rmsd_header, concat, [('out_file', 'rmsd')]),
         (add_dvars_header, concat, [('out_file', 'dvars')]),
         (add_std_dvars_header, concat, [('out_file', 'std_dvars')]),
 

--- a/fmriprep_rodents/workflows/bold/registration.py
+++ b/fmriprep_rodents/workflows/bold/registration.py
@@ -259,8 +259,8 @@ def init_bold_t1_trans_wf(freesurfer, mem_gb, omp_nthreads, multiecho=False, use
       * :py:func:`~fmriprep_rodents.workflows.bold.registration.init_fsl_bbr_wf`
 
     """
+    from ...patch.workflows.func import init_bold_reference_wf
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-    from niworkflows.func.util import init_bold_reference_wf
     from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
     from niworkflows.interfaces.itk import MultiApplyTransforms
     from niworkflows.interfaces.nilearn import Merge
@@ -377,7 +377,8 @@ def init_bbreg_wf(use_bbr, bold2t1w_dof, bold2t1w_init, omp_nthreads, name='bbre
     This workflow uses FreeSurfer's ``bbregister`` to register a BOLD image to
     a T1-weighted structural image.
 
-    It is a counterpart to :py:func:`~fmriprep_rodents.workflows.bold.registration.init_fsl_bbr_wf`,
+    It is a counterpart to
+    :py:func:`~fmriprep_rodents.workflows.bold.registration.init_fsl_bbr_wf`,
     which performs the same task using FSL's FLIRT with a BBR cost function.
     The ``use_bbr`` option permits a high degree of control over registration.
     If ``False``, standard, affine coregistration will be performed using
@@ -717,7 +718,8 @@ for distortions remaining in the BOLD reference.
     else:
         # Should mostly be hit while building docs
         LOGGER.warning("FSLDIR unset - using packaged BBR schedule")
-        flt_bbr.inputs.schedule = pkgr.resource_filename('fmriprep_rodents', 'data/flirtsch/bbr.sch')
+        flt_bbr.inputs.schedule = pkgr.resource_filename(
+            'fmriprep_rodents', 'data/flirtsch/bbr.sch')
 
     workflow.connect([
         (inputnode, wm_mask, [('t1w_dseg', 'in_seg')]),

--- a/fmriprep_rodents/workflows/bold/registration.py
+++ b/fmriprep_rodents/workflows/bold/registration.py
@@ -259,12 +259,12 @@ def init_bold_t1_trans_wf(freesurfer, mem_gb, omp_nthreads, multiecho=False, use
       * :py:func:`~fmriprep_rodents.workflows.bold.registration.init_fsl_bbr_wf`
 
     """
-    from ...patch.workflows.func import init_bold_reference_wf
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
     from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
     from niworkflows.interfaces.itk import MultiApplyTransforms
     from niworkflows.interfaces.nilearn import Merge
     from niworkflows.interfaces.utils import GenerateSamplingReference
+    from ...patch.workflows.func import init_bold_reference_wf
 
     workflow = Workflow(name=name)
     inputnode = pe.Node(

--- a/fmriprep_rodents/workflows/bold/resampling.py
+++ b/fmriprep_rodents/workflows/bold/resampling.py
@@ -265,7 +265,6 @@ def init_bold_std_trans_wf(
         described outputs.
 
     """
-    from ...patch.workflows.func import init_bold_reference_wf
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
     from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
     from niworkflows.interfaces.itk import MultiApplyTransforms
@@ -273,6 +272,7 @@ def init_bold_std_trans_wf(
     from niworkflows.interfaces.utils import GenerateSamplingReference
     from niworkflows.interfaces.nilearn import Merge
     from niworkflows.utils.spaces import format_reference
+    from ...patch.workflows.func import init_bold_reference_wf
 
     workflow = Workflow(name=name)
     output_references = spaces.cached.get_spaces(nonstandard=False, dim=(3,))

--- a/fmriprep_rodents/workflows/bold/resampling.py
+++ b/fmriprep_rodents/workflows/bold/resampling.py
@@ -526,13 +526,14 @@ the transforms to correct for head-motion""")
                     mem_gb=mem_gb * 3)
 
     # Generate a new BOLD reference
-    bold_reference_wf = init_bold_reference_wf(omp_nthreads=omp_nthreads)
+    bold_reference_wf = init_bold_reference_wf(omp_nthreads=omp_nthreads, pre_mask=True)
     bold_reference_wf.__desc__ = None  # Unset description to avoid second appearance
 
     workflow.connect([
         (inputnode, merge, [('name_source', 'header_source')]),
         (bold_transform, merge, [('out_files', 'in_files')]),
         (merge, bold_reference_wf, [('out_file', 'inputnode.bold_file')]),
+        (inputnode, bold_reference_wf, [('bold_mask', 'inputnode.bold_mask')]),
         (merge, outputnode, [('out_file', 'bold')]),
         (bold_reference_wf, outputnode, [
             ('outputnode.ref_image', 'bold_ref'),

--- a/fmriprep_rodents/workflows/bold/resampling.py
+++ b/fmriprep_rodents/workflows/bold/resampling.py
@@ -265,8 +265,8 @@ def init_bold_std_trans_wf(
         described outputs.
 
     """
+    from ...patch.workflows.func import init_bold_reference_wf
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-    from niworkflows.func.util import init_bold_reference_wf
     from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
     from niworkflows.interfaces.itk import MultiApplyTransforms
     from niworkflows.interfaces.utility import KeySelect
@@ -492,8 +492,8 @@ def init_bold_preproc_trans_wf(mem_gb, omp_nthreads,
         Same as ``bold_ref``, but once the brain mask has been applied
 
     """
+    from ...patch.workflows.func import init_bold_reference_wf
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
-    from niworkflows.func.util import init_bold_reference_wf
     from niworkflows.interfaces.itk import MultiApplyTransforms
     from niworkflows.interfaces.nilearn import Merge
 

--- a/scripts/generate_reference_mask.py
+++ b/scripts/generate_reference_mask.py
@@ -2,7 +2,7 @@
 import sys
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
-from niworkflows.func.util import init_bold_reference_wf
+from fmriprep_rodents.patch.workflows.func import init_bold_reference_wf
 
 
 def sink_mask_file(in_file, orig_file, out_dir):


### PR DESCRIPTION
Swapped in `artsBrainExtraction` workflow for all occurrences of `niworkflows.func.util.init_bold_reference_wf`, because it had inappropriate masking methods. The result isn't very efficient, but it gets things moving.

Goes some way to fix #13, but it seems something is going wrong with the MCFLIRT transformation, so that's next on the list.