### PR TITLE
FIX: Cleanup dependencies

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -69,6 +69,7 @@ jobs:
         python -m pip install "${{ matrix.pip }}" setuptools
         python -m pip install numpy scipy "Cython >= 0.28.5" # sklearn needs this
         python -m pip install scikit-learn  # otherwise it attempts to build it
+        python -m pip install "matplotlib ~= 3.3.1"  # otherwise nilearn installs the latest
         python setup.py install
         INSTALLED_VERSION=$(python -c 'import fprodents; print(fprodents.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""
@@ -81,6 +82,7 @@ jobs:
         # sklearn needs these dependencies
         python -m pip install numpy scipy "Cython >= 0.28.5"
         python -m pip install scikit-learn  # otherwise it attempts to build it
+        python -m pip install "matplotlib ~= 3.3.1"  # otherwise nilearn installs the latest
         python setup.py develop
         INSTALLED_VERSION=$(python -c 'import fprodents; print(fprodents.__version__, end="")')
         echo "INSTALLED: \"${INSTALLED_VERSION}\""

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,17 +20,14 @@ url = https://github.com/poldracklab/fmriprep-rodents
 [options]
 python_requires = >=3.7
 install_requires =
-    indexed_gzip >= 0.8.8
     nibabel >= 3.0
     nipype ~= 1.5.1
-    nitime
     nitransforms ~= 21.0.0
     niworkflows ~= 1.4.0
     nirodents >= 0.2.4
     numpy
     pandas
-    psutil >= 5.4
-    pybids >= 0.11.1
+    pybids >= 0.12.1
     pyyaml
     requests
     smriprep >= 0.8.0rc0


### PR DESCRIPTION
Addresses the build issue that comes up after the latest release of nilearn.

The strategy would be not to run these tests always, but only on the `rel/*` and on tags. They are only necessary to ensure that the package is correctly built and installed, so it doesn't make sense to keep track of this all the time, it's only necessary when we're about to release.

heads-up @eilidhmacnicol - I'm merging this for now so you can go ahead and fix your PR.