### PR TITLE
MAINT: Rotate CircleCI secrets and setup up org-level context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,6 +365,8 @@ workflows:
   build_test_deploy:
     jobs:
       - build:
+          context:
+            - nipreps-common
           filters:
             branches:
               ignore:


### PR DESCRIPTION
Responding to CircleCI's security alert on Jan 4, 2023 this PR rotates the secrets of this project.